### PR TITLE
Fix for comparing files with right seq (#46uhcq)

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -25,28 +25,26 @@ func filter(updates []update, tx *sql.Tx) ([]update, error) {
 	}
 
 	remaining := make([]update, len(updates))
-	for i := range updates {
-		remaining[i] = updates[i]
-	}
+	copy(remaining, updates)
 
 	// Check that applied updates match available updates
-	for _, up := range applied {
+	for i, up := range applied {
 		if len(updates) == 0 {
 			return nil, UpdateSchemaError(
 				fmt.Errorf("unknown update %d already applied", up.seq),
 			)
 		}
-		if up.seq != updates[0].seq {
+		if up.seq != updates[i].seq {
 			return nil, UpdateSchemaError(
-				fmt.Errorf("update %d seen instead of expected %d", up.seq, updates[0].seq),
+				fmt.Errorf("update %d seen instead of expected %d", up.seq, updates[i].seq),
 			)
 		}
-		if up.sha1 != updates[0].sha1 {
+		if up.sha1 != updates[i].sha1 {
 			return nil, UpdateSchemaError(fmt.Errorf(
 				"checksum of applied update %d (%s) does not match expected (%s)",
 				up.seq,
 				up.sha1,
-				updates[0].sha1,
+				updates[i].sha1,
 			))
 		}
 		remaining = remaining[1:]

--- a/open_test.go
+++ b/open_test.go
@@ -222,3 +222,18 @@ func TestOpenSchemaUpdatesEntriesInvalidChecksumFails(t *testing.T) {
 		t.Errorf("expected Open() to fail with UpdateSchemaError")
 	}
 }
+
+func TestSchemaReapplyWithMultipleFiles(t *testing.T) {
+	f := http.Dir("./test/correct_entries")
+	db, err := Open("sqlite3", "file:test.db?mode=memory", f)
+	if err != nil {
+		t.Errorf("expected Open() to succeed but failed with error: %v", err)
+
+	}
+	defer db.Close()
+
+	if err = Apply(db, f); err != nil {
+		t.Errorf("expected Apply() to succeed but failed with error: %v", err)
+	}
+
+}


### PR DESCRIPTION
During investigation of [bug](https://app.clickup.com/t/46uhcq) I find that if we have multiple changesets that needs to be executed. If we apply those changes first time it will work. But if call Apply again we get seq mismatch error, as in filter we are always check for index of 0.

While we are at this repository i have another unrelated topic :)

I have another pending issue with this library is when start project first time, it will create table in public, but after first Apply changes somehow portal schema takes priority and another table is created in porta.schema_updates and for some reason postgresql start to read from portal.schema_updates and write in public.schema_updates.

Hopefully i will solve this by adding search_path=public,portal, in connection string.


